### PR TITLE
Add GitHub Skills Activity - Resolves #6

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🎓 Add GitHub Skills Activity

This PR adds the missing "GitHub Skills" activity that was announced by the principal but was not available on the signup page.

### 📋 Changes Made

- ✅ Added "GitHub Skills" activity to the activities dictionary
- ✅ Included description highlighting GitHub Certifications program benefits for college applications
- ✅ Set schedule: Mondays and Wednesdays, 3:30 PM - 4:30 PM
- ✅ Set capacity: 25 students (good for a popular new program)
- ✅ Ready for immediate student registration

### 🎯 Problem Solved

**Issue**: Students couldn't find the GitHub Skills activity that was announced by the principal in the school assembly.

**Solution**: Added the activity to the system so students can now register before the end-of-week deadline.

### 🔗 References

Closes #6

### 👨‍🎓 Student Impact

- Students can now register for the time-sensitive GitHub Skills program
- Helps with college applications through GitHub Certifications
- Addresses the urgent need mentioned by Hewbie C. (11th Grade Student)

---

**Ready for review and merge** 🚀